### PR TITLE
CI add deployment to pypi with tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,13 @@ deploy:
       # push only once
       python: "3.7"
     local_dir: docs/build/html/
+
+  - provider: pypi
+    user: "__token__"
+    password: $PYPI_TOKEN
+    on:
+      distributions: sdist
+      tags: true
+      branch: master
+      repo: gallantlab/pymoten
+      python: "3.7"


### PR DESCRIPTION
Do not merge yet, we'll need to set up a `PYPI_TOKEN` on pypi first

closes #7 