### PR TITLE
Update setup.py to install in windows environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if not 'extra_setuptools_args' in globals():
     extra_setuptools_args = dict()
 
 
-with open('README.rst', 'r') as fid:
+with open('README.rst', 'r', encoding="utf-8") as fid:
     long_description = fid.read()
 
 


### PR DESCRIPTION
By adding this argument,  it resolved the issue of pymoten not being able to be installed on Windows due to problems with Python’s default encoding on Windows.

The error message when this argument is not present is as follows. "UnicodeDecodeError: 'cp932' codec can't decode byte 0x93 in position 2845: illegal multibyte sequence"