### PR TITLE
Add backend usage example and tidy benchmark scripts in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,35 @@ Simple example using a video file
    moten_features = pyramid.project_stimulus(luminance_images)
 
 
+GPU acceleration
+================
+
+``pymoten`` supports multiple computational backends. By default it runs on the
+CPU with NumPy, but it can also run on the GPU using PyTorch, which is much
+faster for large stimuli. The available backends are ``"numpy"`` (default),
+``"torch"``, ``"torch_cuda"`` (NVIDIA GPUs), and ``"torch_mps"`` (Apple Silicon
+GPUs). The torch backends require `PyTorch <https://pytorch.org>`_ to be
+installed.
+
+.. code-block:: python
+
+   import moten
+   from moten.backend import set_backend
+
+   # Switch to a GPU backend (returns the backend module)
+   backend = set_backend("torch_cuda")
+
+   pyramid = moten.get_default_pyramid(vhsize=(vdim, hdim), fps=24)
+
+   # Move the stimulus onto the GPU, project, then bring the result back
+   stimulus_gpu = backend.asarray(luminance_images)
+   moten_features = pyramid.project_stimulus_batched(stimulus_gpu)
+   moten_features = backend.to_numpy(moten_features)
+
+See the `examples gallery <https://gallantlab.org/pymoten/auto_examples/index.html>`_
+for a complete walkthrough.
+
+
 .. |Build Status| image:: https://travis-ci.org/gallantlab/pymoten.svg?branch=main
     :target: https://travis-ci.org/gallantlab/pymoten
     

--- a/benchmarks/benchmark_backends.py
+++ b/benchmarks/benchmark_backends.py
@@ -8,9 +8,9 @@ Compare motion energy computation speed across available backends
 
 Usage::
 
-    python examples/benchmark_backends.py
-    python examples/benchmark_backends.py --nimages 200 --vdim 128 --hdim 256
-    python examples/benchmark_backends.py --backends numpy torch_cuda
+    python benchmarks/benchmark_backends.py
+    python benchmarks/benchmark_backends.py --nimages 200 --vdim 128 --hdim 256
+    python benchmarks/benchmark_backends.py --backends numpy torch_cuda
 """
 import argparse
 import os

--- a/benchmarks/compare_numpy_vs_gpu.py
+++ b/benchmarks/compare_numpy_vs_gpu.py
@@ -6,9 +6,9 @@ numpy and a GPU backend (torch_mps or torch_cuda), and saves the results.
 
 Usage::
 
-    python examples/demo_numpy_vs_gpu.py
-    python examples/demo_numpy_vs_gpu.py --backend torch_cuda
-    python examples/demo_numpy_vs_gpu.py --nimages 100 --output my_features.npz
+    python benchmarks/compare_numpy_vs_gpu.py
+    python benchmarks/compare_numpy_vs_gpu.py --backend torch_cuda
+    python benchmarks/compare_numpy_vs_gpu.py --nimages 100 --output my_features.npz
 """
 import argparse
 import os

--- a/examples/introduction/demo_backends.py
+++ b/examples/introduction/demo_backends.py
@@ -1,0 +1,149 @@
+'''
+=================================================
+ Using different backends (NumPy, PyTorch, GPU)
+=================================================
+
+This example shows how to use the different computational backends available in
+``pymoten`` to extract motion energy features. Backends let you run the exact
+same pyramid projection on the CPU with NumPy (the default) or on the GPU with
+PyTorch, which can be substantially faster for large stimuli.
+
+The available backends are:
+
+- ``"numpy"``: CPU backend using NumPy (the default).
+- ``"torch"``: CPU backend using PyTorch.
+- ``"torch_cuda"``: GPU backend using PyTorch with CUDA (NVIDIA GPUs).
+- ``"torch_mps"``: GPU backend using PyTorch with Metal (Apple Silicon GPUs).
+  Note that the MPS backend runs in ``float32`` precision only, so results are
+  slightly less precise than the other backends.
+
+The numpy backend is always available. The torch backends additionally require
+`PyTorch <https://pytorch.org>`_ to be installed, and the GPU backends require a
+compatible GPU.
+'''
+
+# %%
+# Selecting a backend
+# ===================
+#
+# Backends are managed with :func:`moten.backend.set_backend` and
+# :func:`moten.backend.get_backend`. The default backend is ``"numpy"``.
+
+import numpy as np
+import moten
+from moten.backend import set_backend, get_backend, ALL_BACKENDS
+
+print("Available backends:", ALL_BACKENDS)
+print("Current backend:", get_backend().name)
+
+# %%
+# Computing features with the NumPy backend
+# =========================================
+#
+# Let us create a small synthetic stimulus and a motion energy pyramid. We use
+# random noise here so the example runs quickly and reproducibly, but in
+# practice you would load a video with :func:`moten.io.video2luminance`.
+
+nimages, vdim, hdim = (100, 72, 128)
+stimulus_fps = 24
+
+rng = np.random.RandomState(0)
+luminance_images = rng.randn(nimages, vdim, hdim)
+
+pyramid = moten.pyramids.MotionEnergyPyramid(stimulus_vhsize=(vdim, hdim),
+                                             stimulus_fps=stimulus_fps)
+print(pyramid)
+
+# %%
+# With the numpy backend, ``project_stimulus`` works exactly as in the other
+# examples and returns a NumPy array of shape ``(nimages, nfilters)``.
+
+set_backend("numpy")
+features_numpy = pyramid.project_stimulus(luminance_images)
+print(type(features_numpy), features_numpy.shape)
+
+# %%
+# Per-filter vs. batched projection
+# =================================
+#
+# Each backend exposes two projection methods. ``project_stimulus`` loops over
+# the filters one at a time (lower memory use), while
+# ``project_stimulus_batched`` groups filters into batches and computes them with
+# large matrix multiplications. The batched version is what unlocks most of the
+# GPU speed-up, but it produces the same result on any backend.
+
+features_batched = pyramid.project_stimulus_batched(luminance_images,
+                                                    batch_size=128)
+print("Per-filter and batched results match:",
+      np.allclose(features_numpy, features_batched))
+
+# %%
+# Using a GPU backend
+# ===================
+#
+# Switching to a GPU backend is a two-step process:
+#
+# 1. Call :func:`moten.backend.set_backend` with the backend name. This returns
+#    the backend module.
+# 2. Move the stimulus onto the device with ``backend.asarray(...)`` before
+#    projecting. The result lives on the GPU, so convert it back to a NumPy
+#    array with ``backend.to_numpy(...)``.
+#
+# Here we try the GPU backends in turn. We pass ``on_error="warn"`` so that, on
+# machines without a GPU (such as the documentation build server), the call
+# simply warns and keeps the current backend instead of raising. This lets the
+# example run everywhere while still demonstrating the GPU API.
+
+gpu_backend = None
+for name in ["torch_cuda", "torch_mps"]:
+    backend = set_backend(name, on_error="warn")
+    if backend.name == name:
+        gpu_backend = name
+        break
+
+if gpu_backend is None:
+    print("No GPU backend available; skipping the GPU comparison.")
+else:
+    print(f"Using GPU backend: {gpu_backend}")
+
+    # Move the stimulus to the GPU.
+    stimulus_gpu = backend.asarray(luminance_images)
+
+    # Project on the GPU (batched is recommended for speed).
+    features_gpu = pyramid.project_stimulus_batched(stimulus_gpu,
+                                                    batch_size=128)
+
+    # Bring the result back to the CPU as a NumPy array.
+    features_gpu = backend.to_numpy(features_gpu)
+
+    # Compare against the numpy reference. The GPU result is computed in
+    # float32, so we only expect agreement up to single precision.
+    max_abs_diff = np.max(np.abs(features_numpy.astype(np.float32)
+                                 - features_gpu.astype(np.float32)))
+    print(f"Max |numpy - {gpu_backend}|: {max_abs_diff:.2e}")
+
+# %%
+# Always reset the backend to numpy when you are done, so that other code is not
+# affected by the global backend setting.
+
+set_backend("numpy")
+
+# %%
+# Benchmarking backends
+# =====================
+#
+# Finally, ``pymoten`` ships a small helper,
+# :func:`moten.backend.benchmark`, that times the per-filter and batched
+# projections on one or all backends. It is handy for checking how much speed-up
+# a GPU gives on your own hardware.
+
+from moten.backend import benchmark
+
+results = benchmark("numpy", nimages=50, vdim=72, hdim=128)
+numpy_result = results["numpy"]
+print(f"numpy per-filter: {numpy_result['duration_seconds']:.3f}s")
+print(f"numpy batched:    {numpy_result['duration_batched_seconds']:.3f}s")
+
+# %%
+# Calling ``benchmark()`` with no arguments times every available backend, so on
+# a machine with a GPU you can directly compare CPU and GPU timings.


### PR DESCRIPTION
## Summary
Following the new backend feature (#53), the docs didn't mention it and the gallery showed CLI scripts as broken source-only entries. This PR fixes both.

- **New gallery example** `examples/introduction/demo_backends.py` — walks through the NumPy/PyTorch backend system: `set_backend`/`get_backend`, per-filter vs. batched projection, the GPU workflow (`asarray` → `project_stimulus_batched` → `to_numpy`), and the `moten.backend.benchmark` helper. The GPU section uses `set_backend(..., on_error="warn")` so it gracefully skips (no error) on machines without a GPU/PyTorch — meaning the example fully **executes on CI via the NumPy path**.
- **README** — added a short "GPU acceleration" section listing the four backends with a minimal usage snippet, since the README is the docs landing page.
- **Moved CLI utilities out of the gallery** — `benchmark_backends.py` and `compare_numpy_vs_gpu.py` moved from `examples/` to a new `benchmarks/` directory. They had RST-title docstrings, so sphinx-gallery rendered them at the top level of the gallery as non-executed source listings. They remain runnable CLI tools; usage paths updated (also fixed a stale `demo_numpy_vs_gpu.py` reference).

## Test plan
- [x] `python examples/introduction/demo_backends.py` runs end-to-end (exercised the real `torch_mps` path locally; float32 diff ~6.6e-3)
- [x] Verified the example skips the GPU section cleanly when no GPU/torch is available (CI behavior)
- [x] `python benchmarks/benchmark_backends.py --backends numpy ...` runs from new location
- [ ] Confirm docs build renders the new example and no longer lists the benchmark scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)